### PR TITLE
improve performance of Iterate Tuple

### DIFF
--- a/src/main/scala/constraints/Iterate.scala
+++ b/src/main/scala/constraints/Iterate.scala
@@ -32,19 +32,7 @@ object Iterate:
    */
   given [T <: Tuple, A](using Tuple.Union[T] <:< A): Iterate[T, A] with
     override def iterable(tuple: T): Iterable[A] = new Iterable[A]:
-      override def iterator: Iterator[A] =
-        new Iterator[A]:
-          var cur: Tuple = tuple
-
-          override def hasNext: Boolean = cur match
-            case EmptyTuple => false
-            case _: NonEmptyTuple => true
-
-          override def next(): A = cur match
-            case EmptyTuple => throw java.util.NoSuchElementException()
-            case head *: tail =>
-              cur = tail
-              head.asInstanceOf[A]
+      override def iterator: Iterator[A] = tuple.productIterator.asInstanceOf[Iterator[A]]
 
   /**
    * The type class instance of [[Iterate]] for [[Iterable]]s


### PR DESCRIPTION
the `*:` extractor should usually be avoided for non-inline code, because it calls `tail`, (i.e. constructing a `Tuple<N-1>`) leading to O(N^2) iteration